### PR TITLE
chore: allow env file tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 /keycloak
 
 # Environment secrets
-.env
 .env.secret
 ngrok.yml
 


### PR DESCRIPTION
## Summary
- Removes the top-level `.env` ignore entry from `.gitignore`
- Keeps `.env.secret` and `ngrok.yml` ignored

## Notes
- Requested by project admin to allow tracking `.env` in this repository.
- No secret values are included in this PR description.

## Test Plan
- Verified branch is based on latest `upstream/collab`
- Verified pushed branch matches local commit
